### PR TITLE
fix config file iterator

### DIFF
--- a/lib/NagParser/File/CfgCollector.php
+++ b/lib/NagParser/File/CfgCollector.php
@@ -24,7 +24,7 @@ class CfgCollector
         $directoryIterator = new \RecursiveDirectoryIterator($directory);
         $iterator = new \RecursiveIteratorIterator($directoryIterator);
 
-        $cfgFiles = new \RegexIterator($iterator, sprintf('#^%s/.+/.+\.cfg$#i', $directory), \RecursiveRegexIterator::GET_MATCH);
+        $cfgFiles = new \RegexIterator($iterator, '#.+\.cfg$#i', \RecursiveRegexIterator::GET_MATCH);
 
         foreach($cfgFiles as $cfgFile){
             $this->paths[] = $cfgFile[0];


### PR DESCRIPTION
I tried to integrate your parser into a project of mine and saw that the discovery of .cfg-files didn't work. I found the error in this line:
https://github.com/markri/nagparser/blob/853fce86f5ea0b6d56dc8d207ef15f1d9652a78d/lib/NagParser/File/CfgCollector.php#L27

I didn't really understand the reason why to use 
```php
sprintf('#^%s/.+/.+\.cfg$#i', $directory)
```
in favor of a simple regex
```php
'#.+\.cfg$#i'
```
because the iterator is already limited to the specified path by
https://github.com/markri/nagparser/blob/853fce86f5ea0b6d56dc8d207ef15f1d9652a78d/lib/NagParser/File/CfgCollector.php#L24

