### PR TITLE
allow more than one parsing directory

### DIFF
--- a/lib/NagParser/File/CfgCollector.php
+++ b/lib/NagParser/File/CfgCollector.php
@@ -16,20 +16,24 @@ class CfgCollector
     private $mergedContent;
 
     /**
-     * Enter nagios config directory e.g. /usr/local/nagios/etc
-     * @param string $directory
+     * Enter nagios config directory/directories e.g. /usr/local/nagios/etc
+     * @param array $directories
      */
-    public function __construct($directory)
-    {
-        $directoryIterator = new \RecursiveDirectoryIterator($directory);
-        $iterator = new \RecursiveIteratorIterator($directoryIterator);
+	public function __construct($directories)
+	{
+		foreach ($directories as $directory)
+		{
+			$directoryIterator = new \RecursiveDirectoryIterator($directory);
+			$iterator = new \RecursiveIteratorIterator($directoryIterator);
 
-        $cfgFiles = new \RegexIterator($iterator, '#.+\.cfg$#i', \RecursiveRegexIterator::GET_MATCH);
+			$cfgFiles = new \RegexIterator($iterator, '#.+\.cfg$#i', \RecursiveRegexIterator::GET_MATCH);
 
-        foreach($cfgFiles as $cfgFile){
-            $this->paths[] = $cfgFile[0];
-        }
-    }
+			foreach ($cfgFiles as $cfgFile)
+			{
+				$this->paths[] = $cfgFile[0];
+			}
+		}
+	}
 
 
     /**

--- a/lib/NagParser/Parser.php
+++ b/lib/NagParser/Parser.php
@@ -13,16 +13,27 @@ class Parser
 
     /**
      * @param string $directory
+     * @param array $additionalDirectories
      */
-    public function __construct($directory)
-    {
-        if (!file_exists($directory)) {
-            throw new \InvalidArgumentException(sprintf('Root dir %s doesnt exist', $directory));
-        }
+	public function __construct($directory, array $additionalDirectories = null)
+	{
+		$directories = array();
+		if (is_array($additionalDirectories))
+		{
+			$directories = array_merge($directories, $additionalDirectories);
+		}
 
-        $cfgCollector = new CfgCollector($directory);
-        $this->content = $cfgCollector->getMergedContent();
-    }
+		array_push($directories, $directory);
+
+		foreach ($directories as $dir)
+		{
+			if (!file_exists($dir))
+				throw new \InvalidArgumentException(sprintf('Root dir %s doesnt exist', $dir));
+		}
+
+		$cfgCollector = new CfgCollector($directories);
+		$this->content = $cfgCollector->getMergedContent();
+	}
 
     /**
      *


### PR DESCRIPTION
On our Nagios servers we have more than one instance which share some of their config in a shared directory. With this change it will be able to parse more than one directory. 