### PR TITLE
fix multiline parsing

### DIFF
--- a/lib/NagParser/Definitions/Definition.php
+++ b/lib/NagParser/Definitions/Definition.php
@@ -16,9 +16,9 @@ abstract class Definition
 
     private function parseConfig($config)
     {
-		$config = preg_replace('/\s*\\\[\n\r]\s*/', '', $config);
+        $config = preg_replace('/\s*\\\[\n\r]\s*/', '', $config);
         preg_match_all('/^\s*(.+?)\s+(.+)$/m', $config, $matches);
-		$matches[2] = array_map('trim', $matches[2]);
+        $matches[2] = array_map('trim', $matches[2]);
         $this->config = array_combine($matches[1], $matches[2]);
     }
 

--- a/lib/NagParser/Definitions/Definition.php
+++ b/lib/NagParser/Definitions/Definition.php
@@ -16,6 +16,7 @@ abstract class Definition
 
     private function parseConfig($config)
     {
+		$config = preg_replace('/\s*\\\[\n\r]\s*/', '', $config);
         preg_match_all('/^\s*(.+?)\s+(.+)$/m', $config, $matches);
 		$matches[2] = array_map('trim', $matches[2]);
         $this->config = array_combine($matches[1], $matches[2]);


### PR DESCRIPTION
Nagios allows to have values defined in multiple lines by doing something like this

```
define host {
	host_name    Host1
	contact_groups 	ContactGroup1, \
			ContactGroup2, \
			ContactGroup3
	contacts	Contact1, \
			Contact2
}
```

Without this change, the parsing does not work and looks like this:
![image](https://user-images.githubusercontent.com/26710574/89412072-babe8a80-d726-11ea-8ef7-ba63bafb57cb.png)


After the change, the result is this: 
![image](https://user-images.githubusercontent.com/26710574/89411988-9b276200-d726-11ea-909f-cbe56713a714.png)
